### PR TITLE
DMP-1346: replace `repository.findById` with `repository.getReferenceById`

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
+++ b/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
@@ -197,7 +197,6 @@ public class TestSupportController {
             auditRepository.saveAndFlush(audit);
             return new ResponseEntity<>(CREATED);
         } catch (DataIntegrityViolationException e) {
-            // if I let the exception bubble up we'd get a 500 status code, I need to catch it
             throw new ResponseStatusException(BAD_REQUEST);
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
+++ b/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
@@ -7,6 +7,7 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.darts.audit.api.AuditActivity;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.AuditActivityEntity;
@@ -162,7 +164,7 @@ public class TestSupportController {
     }
 
     @PostMapping(value = "/audit/{audit_activity}/courthouse/{courthouse_name}")
-    @Transactional
+    @Transactional(rollbackOn = DataIntegrityViolationException.class)
     public ResponseEntity<String> createAudit(@PathVariable(name = "audit_activity") String auditActivity,
                                               @PathVariable(name = "courthouse_name") String courthouseName) {
 
@@ -184,19 +186,20 @@ public class TestSupportController {
         AuditEntity audit = new AuditEntity();
         audit.setCourtCase(savedCase);
         audit.setUser(userAccountRepository.getReferenceById(0));
-        Optional<AuditActivityEntity> foundAuditActivity = auditActivityRepository.findById(AuditActivity.valueOf(
-            auditActivity).getId());
+        try {
+            AuditActivityEntity foundAuditActivity = auditActivityRepository.getReferenceById(
+                AuditActivity.valueOf(auditActivity).getId()
+            );
+            audit.setAuditActivity(foundAuditActivity);
 
-        if (foundAuditActivity.isPresent()) {
-            audit.setAuditActivity(foundAuditActivity.get());
-        } else {
-            return new ResponseEntity<>(BAD_REQUEST);
+            audit.setApplicationServer(applicationServer);
+
+            auditRepository.saveAndFlush(audit);
+            return new ResponseEntity<>(CREATED);
+        } catch (DataIntegrityViolationException e) {
+            // if I let the exception bubble up we'd get a 500 status code, I need to catch it
+            throw new ResponseStatusException(BAD_REQUEST);
         }
-
-        audit.setApplicationServer(applicationServer);
-        auditRepository.saveAndFlush(audit);
-
-        return new ResponseEntity<>(CREATED);
     }
 
     private CourthouseEntity newCourthouse(String courthouseName) {

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
@@ -17,7 +17,7 @@ import java.util.List;
 public interface ExternalObjectDirectoryRepository extends JpaRepository<ExternalObjectDirectoryEntity, Integer> {
 
     @Query(
-        "SELECT eod FROM ExternalObjectDirectoryEntity eod, MediaEntity med " +
+        "SELECT eod FROM ExternalObjectDirectoryEntity eod " +
             "WHERE eod.media = :media AND eod.status = :status AND eod.externalLocationType = :externalLocationType"
     )
     List<ExternalObjectDirectoryEntity> findByMediaStatusAndType(MediaEntity media, ObjectRecordStatusEntity status,


### PR DESCRIPTION
Note: 

I've analyzed all the production code usages of `findById`. 
Apart from one case, I believe all the current usages are legit and should not be replaced by `getReferenceById`. This is because:

- in most of the cases the (non-ID) entity fields are accessed with setters/getters, which would trigger a SQL statement anyway
- in a couple of cases replacing would break the API contract by changing the error currently returned in case the entity does not exist, which is not worth doing



